### PR TITLE
Avoid import :all from LDNS

### DIFF
--- a/lib/DNS/LDNS/DNSSecDataChain.pm
+++ b/lib/DNS/LDNS/DNSSecDataChain.pm
@@ -4,7 +4,7 @@ use 5.008008;
 use strict;
 use warnings;
 
-use DNS::LDNS;
+use DNS::LDNS ();
 
 our $VERSION = '0.62';
 
@@ -52,7 +52,7 @@ DNS::LDNS::DNSSecDataChain - DNSSec data chain element
 
 =head1 SYNOPSIS
 
-  use DNS::LDNS ':all'
+  use DNS::LDNS ();
 
   chain = new DNS::LDNS::DNSSecDataChain
   chain->print(fp)

--- a/lib/DNS/LDNS/DNSSecName.pm
+++ b/lib/DNS/LDNS/DNSSecName.pm
@@ -4,7 +4,7 @@ use 5.008008;
 use strict;
 use warnings;
 
-use DNS::LDNS ':all';
+use DNS::LDNS ();
 
 our $VERSION = '0.62';
 
@@ -76,7 +76,7 @@ DNS::LDNS::DNSSecName - Dname with rrsets in a dnssec zone
 
 =head1 SYNOPSIS
 
-  use LDNS ':all'
+  use LDNS ();
 
   my name = new DNS::LDNS::DNSSecName
 

--- a/lib/DNS/LDNS/DNSSecRRSets.pm
+++ b/lib/DNS/LDNS/DNSSecRRSets.pm
@@ -4,7 +4,7 @@ use 5.008008;
 use strict;
 use warnings;
 
-use DNS::LDNS;
+use DNS::LDNS ();
 
 our $VERSION = '0.62';
 
@@ -56,7 +56,7 @@ DNS::LDNS::DNSSecRRSets - Linked list of rrsets in a dnssec zone
 
 =head1 SYNOPSIS
 
-  use DNS::LDNS ':all'
+  use DNS::LDNS ();
 
   rrs = rrsets->rrs
   rrs = rrsets->signatures

--- a/lib/DNS/LDNS/DNSSecRRs.pm
+++ b/lib/DNS/LDNS/DNSSecRRs.pm
@@ -4,7 +4,7 @@ use 5.008008;
 use strict;
 use warnings;
 
-use DNS::LDNS;
+use DNS::LDNS ();
 
 our $VERSION = '0.62';
 
@@ -56,7 +56,7 @@ DNS::LDNS::DNSSecRRs - Linked list of rrs in a dnssec zone
 
 =head1 SYNOPSIS
 
-  use DNS::LDNS ':all'
+  use DNS::LDNS ()
 
   rrs->to_string
   rrs->add_rr(rr)

--- a/lib/DNS/LDNS/DNSSecTrustTree.pm
+++ b/lib/DNS/LDNS/DNSSecTrustTree.pm
@@ -4,7 +4,7 @@ use 5.008008;
 use strict;
 use warnings;
 
-use DNS::LDNS;
+use DNS::LDNS ();
 
 our $VERSION = '0.62';
 
@@ -64,7 +64,7 @@ DNS::LDNS::DNSSecTrustTree - Trust tree from signed RR to trust anchors
 
 =head1 SYNOPSIS
 
-  use DNS::LDNS ':all'
+  use DNS::LDNS ();
 
   tree = new DNS::LDNS::DNSSecTrustTree
   tree->print(fp)

--- a/lib/DNS/LDNS/DNSSecZone.pm
+++ b/lib/DNS/LDNS/DNSSecZone.pm
@@ -4,7 +4,7 @@ use 5.008008;
 use strict;
 use warnings;
 
-use DNS::LDNS ':all';
+use DNS::LDNS ();
 
 our $VERSION = '0.62';
 
@@ -12,13 +12,13 @@ sub new {
     my ($class, %args) = @_;
 
     my $line_nr;
-    my $status = &LDNS_STATUS_OK;
+    my $status = &DNS::LDNS::LDNS_STATUS_OK;
     my $zone;
     my $file;
 
     if ($args{filename}) {
 	unless (open FILE, $args{filename}) {
-	    $DNS::LDNS::last_status = &LDNS_STATUS_FILE_ERR;
+	    $DNS::LDNS::last_status = &DNS::LDNS::LDNS_STATUS_FILE_ERR;
 	    $DNS::LDNS::line_nr = 0;
 	    return;
 	}
@@ -125,7 +125,7 @@ DNS::LDNS::DNSSecZone - Zone with dnssec data
 
 =head1 SYNOPSIS
 
-  use DNS::LDNS ':all'
+  use DNS::LDNS ();
 
   my z = new DNS::LDNS::DNSSecZone(
     filename => '/path/to/myzone',

--- a/lib/DNS/LDNS/Key.pm
+++ b/lib/DNS/LDNS/Key.pm
@@ -4,7 +4,7 @@ use 5.008008;
 use strict;
 use warnings;
 
-use DNS::LDNS ':all';
+use DNS::LDNS ();
 
 our $VERSION = '0.62';
 
@@ -14,12 +14,12 @@ sub new {
     my $key;
 
     if ($args{filename} or $args{file}) {
-	my $status = &LDNS_STATUS_OK;
+	my $status = &DNS::LDNS::LDNS_STATUS_OK;
 	my $line_nr = 0;
 	my $file = $args{file};
 	if ($args{filename}) {
 	    unless (open FILE, $args{filename}) {
-		$DNS::LDNS::last_status = &LDNS_STATUS_FILE_ERR;
+		$DNS::LDNS::last_status = &DNS::LDNS::LDNS_STATUS_FILE_ERR;
 		return;
 	    }
 	    $file = \*FILE;
@@ -69,7 +69,7 @@ DNS::LDNS::Key - DNSSec private key
 
 =head1 SYNOPSIS
 
-  use DNS::LDNS ':all'
+  use DNS::LDNS ();
 
   key = new DNS::LDNS::Key
   key = new DNS::LDNS::Key(file => \*FILE)

--- a/lib/DNS/LDNS/KeyList.pm
+++ b/lib/DNS/LDNS/KeyList.pm
@@ -4,7 +4,7 @@ use 5.008008;
 use strict;
 use warnings;
 
-use DNS::LDNS ':all';
+use DNS::LDNS ();
 
 our $VERSION = '0.62';
 
@@ -44,7 +44,7 @@ DNS::LDNS::KeyList - Linked list of dnssec keys
 
 =head1 SYNOPSIS
 
-  use DNS::LDNS ':all'
+  use DNS::LDNS ();
 
   my l = new DNS::LDNS::KeyList
   l->set_use(bool)

--- a/lib/DNS/LDNS/Packet.pm
+++ b/lib/DNS/LDNS/Packet.pm
@@ -4,7 +4,7 @@ use 5.008008;
 use strict;
 use warnings;
 
-use DNS::LDNS;
+use DNS::LDNS ();
 
 our $VERSION = '0.62';
 
@@ -142,7 +142,7 @@ DNS::LDNS::Packet - DNS packet
 
 =head1 SYNOPSIS
 
-  use DNS::LDNS ':all'
+  use DNS::LDNS ();
 
   my pkt = new DNS::LDNS::Packet(name => rdata, type => LDNS_RR_TYPE_...,
     class => LDNS_RR_CLASS_..., flags => ...)

--- a/lib/DNS/LDNS/RBNode.pm
+++ b/lib/DNS/LDNS/RBNode.pm
@@ -4,7 +4,7 @@ use 5.008008;
 use strict;
 use warnings;
 
-use DNS::LDNS;
+use DNS::LDNS ();
 
 our $VERSION = '0.62';
 
@@ -45,7 +45,7 @@ DNS::LDNS::RBNode - Node in the RBTree
 
 =head1 SYNOPSIS
 
-  use DNS::LDNS ':all'
+  use DNS::LDNS ();
 
   node2 = node->next
   node2 = node->next_nonglue

--- a/lib/DNS/LDNS/RBTree.pm
+++ b/lib/DNS/LDNS/RBTree.pm
@@ -4,7 +4,7 @@ use 5.008008;
 use strict;
 use warnings;
 
-use DNS::LDNS;
+use DNS::LDNS ();
 
 our $VERSION = '0.62';
 
@@ -35,7 +35,7 @@ DNS::LDNS::RBTree - Tree of DNSSecName nodes
 
 =head1 SYNOPSIS
 
-  use DNS::LDNS ':all'
+  use DNS::LDNS ();
 
   rbnode = rbtree->first
   rbnode = rbtree->last

--- a/lib/DNS/LDNS/RData.pm
+++ b/lib/DNS/LDNS/RData.pm
@@ -4,7 +4,7 @@ use 5.008008;
 use strict;
 use warnings;
 
-use DNS::LDNS;
+use DNS::LDNS ();
 
 our $VERSION = '0.62';
 
@@ -40,7 +40,7 @@ DNS::LDNS::RData - Rdata field or a dname in an rr
 
 =head1 SYNOPSIS
 
-  use DNS::LDNS ':all'
+  use DNS::LDNS ();
 
   my rd = new DNS::LDNS::RData(rdf_type, str)
   rd2 = rd->clone

--- a/lib/DNS/LDNS/RR.pm
+++ b/lib/DNS/LDNS/RR.pm
@@ -4,7 +4,7 @@ use 5.008008;
 use strict;
 use warnings;
 
-use DNS::LDNS ':all';
+use DNS::LDNS ();
 
 our $VERSION = '0.62';
 
@@ -12,7 +12,7 @@ sub new {
     my $class = shift;
 
     my $rr;
-    my $status = &LDNS_STATUS_OK;
+    my $status = &DNS::LDNS::LDNS_STATUS_OK;
 
     if (scalar(@_) == 0) {
 	$rr = _new;
@@ -37,7 +37,7 @@ sub new {
 	    my $file = $args{file};
 	    if ($args{filename}) {
 		unless (open FILE, $args{filename}) {
-		    $DNS::LDNS::last_status = &LDNS_STATUS_FILE_ERR;
+		    $DNS::LDNS::last_status = &DNS::LDNS::LDNS_STATUS_FILE_ERR;
 		    $DNS::LDNS::line_nr = 0;
 		    return;
 		}
@@ -61,14 +61,14 @@ sub new {
 	    $rr = _new_from_type($args{type});
 	    if ($args{owner}) {
 		$rr->set_owner(ref $args{owner} ? $args{owner} : 
-		    new DNS::LDNS::RData(&LDNS_RDF_TYPE_DNAME, $args{owner}));
+		    new DNS::LDNS::RData(&DNS::LDNS::LDNS_RDF_TYPE_DNAME, $args{owner}));
 	    }
 	    $rr->set_ttl($args{ttl}) if ($args{ttl});
 	    $rr->set_class($args{class}) if ($args{class});
 
 	    if ($args{rdata}) {
 		if (!$rr->set_rdata(@{$args{rdata}})) {
-		    $DNS::LDNS::last_status = &LDNS_STATUS_SYNTAX_RDATA_ERR;
+		    $DNS::LDNS::last_status = &DNS::LDNS::LDNS_STATUS_SYNTAX_RDATA_ERR;
 		    return;
 		}
 	    }
@@ -110,7 +110,7 @@ sub set_rdata {
 
     if (scalar @rdata != $self->rd_count) {
 	# Hopefully this is a proper error to return here...
-	$DNS::LDNS::last_status = LDNS_STATUS_SYNTAX_RDATA_ERR;
+	$DNS::LDNS::last_status = &DNS::LDNS::LDNS_STATUS_SYNTAX_RDATA_ERR;
 	return;
     }
     my $i = 0;
@@ -347,7 +347,7 @@ sub verify_denial_nsec3_match {
     my $status;
     my $match = _verify_denial_nsec3_match($self, $nsecs, $rrsigs, $packet_rcode, $packet_qtype, $packet_nodata, $status);
     $DNS::LDNS::last_status = $status;
-    if ($status != &LDNS_STATUS_OK) {
+    if ($status != &DNS::LDNS::LDNS_STATUS_OK) {
 	return;
     }
 
@@ -368,7 +368,7 @@ DNS::LDNS::RR - Resource record
 
 =head1 SYNOPSIS
 
-  use DNS::LDNS ':all'
+  use DNS::LDNS ();
 
   my rr = new DNS::LDNS::RR('mylabel 3600 IN A 168.10.10.10')
   my rr = new DNS::LDNS::RR(

--- a/lib/DNS/LDNS/RRList.pm
+++ b/lib/DNS/LDNS/RRList.pm
@@ -4,7 +4,7 @@ use 5.008008;
 use strict;
 use warnings;
 
-use DNS::LDNS;
+use DNS::LDNS ();
 
 our $VERSION = '0.62';
 
@@ -117,7 +117,7 @@ DNS::LDNS::RRList - List of rrs
 
 =head1 SYNOPSIS
 
-  use DNS::LDNS ':all'
+  use DNS::LDNS ();
 
   my l = new DNS::LDNS::RRList
   my l = new DNS::LDNS::RRList(hosts_file => \*FILE)

--- a/lib/DNS/LDNS/Resolver.pm
+++ b/lib/DNS/LDNS/Resolver.pm
@@ -4,7 +4,7 @@ use 5.008008;
 use strict;
 use warnings;
 
-use DNS::LDNS ':all';
+use DNS::LDNS ();
 
 our $VERSION = '0.62';
 
@@ -12,11 +12,11 @@ sub new {
     my ($class, %args) = @_;
     
     my $file;
-    my $status = &LDNS_STATUS_OK;
+    my $status = &DNS::LDNS::LDNS_STATUS_OK;
 
     if ($args{filename}) {
 	unless (open FILE, $args{filename}) {
-	    $DNS::LDNS::last_status = &LDNS_STATUS_FILE_ERR;
+	    $DNS::LDNS::last_status = &DNS::LDNS::LDNS_STATUS_FILE_ERR;
 	    $DNS::LDNS::line_nr = 0;
 	    return;
 	}
@@ -166,10 +166,10 @@ sub fetch_valid_domain_keys_time {
 sub prepare_query_pkt {
     my ($self, $rdata, $type, $class, $flags) = @_;
 
-    my $s = &LDNS_STATUS_OK;
+    my $s = &DNS::LDNS::LDNS_STATUS_OK;
     my $qry = _prepare_query_pkt($self, $rdata, $type, $class, $flags, $s);
     $DNS::LDNS::last_status = $s;
-    if ($s != LDNS_STATUS_OK) {
+    if ($s != &DNS::LDNS::LDNS_STATUS_OK) {
 	return;
     }
     return $qry;
@@ -178,10 +178,10 @@ sub prepare_query_pkt {
 sub send {
     my ($self, $rdata, $type, $class, $flags) = @_;
 
-    my $s = &LDNS_STATUS_OK;
+    my $s = &DNS::LDNS::LDNS_STATUS_OK;
     my $ans = _send($self, $rdata, $type, $class, $flags, $s);
     $DNS::LDNS::last_status = $s;
-    if ($s != LDNS_STATUS_OK) {
+    if ($s != &DNS::LDNS::LDNS_STATUS_OK) {
 	return;
     }
     return $ans;
@@ -193,7 +193,7 @@ sub send_pkt {
     my $s = &LDNS_STATUS_OK;
     my $ans = _send_pkt($self, $qry, $s);
     $DNS::LDNS::last_status = $s;
-    if ($s != LDNS_STATUS_OK) {
+    if ($s != &DNS::LDNS::LDNS_STATUS_OK) {
 	return;
     }
     return $ans;
@@ -227,7 +227,7 @@ DNS::LDNS::Resolver - DNS resolver
 
 =head1 SYNOPSIS
 
-  use DNS::LDNS ':all'
+  use DNS::LDNS ();
 
   my r = new DNS::LDNS::Resolver(filename => '/my/resolv.conf')
   my r = new DNS::LDNS::Resolver(file => \*FILE)

--- a/lib/DNS/LDNS/Zone.pm
+++ b/lib/DNS/LDNS/Zone.pm
@@ -4,7 +4,7 @@ use 5.008008;
 use strict;
 use warnings;
 
-use DNS::LDNS ':all';
+use DNS::LDNS ();
 
 our $VERSION = '0.62';
 
@@ -12,13 +12,13 @@ sub new {
     my ($class, %args) = @_;
 
     my $line_nr = 0;
-    my $status = &LDNS_STATUS_OK;
+    my $status = &DNS::LDNS::LDNS_STATUS_OK;
     my $zone;
     my $file;
 
     if ($args{filename}) {
 	unless (open FILE, $args{filename}) {
-	    $DNS::LDNS::last_status = &LDNS_STATUS_FILE_ERR;
+	    $DNS::LDNS::last_status = &DNS::LDNS::LDNS_STATUS_FILE_ERR;
 	    $DNS::LDNS::line_nr = 0;
 	    return;
 	}
@@ -96,7 +96,7 @@ DNS::LDNS::Zone - Parsed zonefile
 
 =head1 SYNOPSIS
 
-  use DNS::LDNS ':all'
+  use DNS::LDNS ();
 
   my z = new DNS::LDNS::Zone(
     filename => '/path/to/myzone',


### PR DESCRIPTION
Avoid importing all constant to multiple namespaces
to reduce the memory footprint.